### PR TITLE
AA-2973 Add ignoreRestSiblings to no-unused-vars rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,10 @@ module.exports = {
         'no-irregular-whitespace': ['error'],
         'space-before-function-paren': ['error', 'always'],
         'no-constant-condition': ['error'],
-        'no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],
+        'no-unused-vars': ['error', {
+            'argsIgnorePattern': '^_',
+            'ignoreRestSiblings': true,
+        }],
         'eol-last': ['error', 'always'],
         'comma-dangle': ['error', 'always-multiline'],
     },


### PR DESCRIPTION
Ads `{ ignoreRestSiblings: true }` to `no-unused-vars` rule to support this use case without triggering a linting error:

```js
const myFunc = ({ somethingNotWanted, ...allTheStuffWanted }) =>
    allTheStuffWanted;

myFunc();
```