### PR TITLE
NO-TICKET magic numbers TS

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,13 @@ module.exports = {
         camelcase: ['error', { properties: 'never' }],
         'no-array-constructor': ['error'],
         'no-loop-func': ['error'],
-        'no-magic-numbers': ['error', { ignore: [0, 1, -1, 2, 100] }],
+        'no-magic-numbers': [
+            'error',
+            {
+                ignore: [0, 1, -1, 2, 100],
+                detectObjects: true,
+            },
+        ],
         'no-redeclare': ['error'],
         'no-unused-expressions': ['error'],
         'no-use-before-define': ['error'],

--- a/typescript.js
+++ b/typescript.js
@@ -1,9 +1,15 @@
 module.exports = {
     rules: {
-        '@typescript-eslint/no-magic-numbers': [
-            'error',
-            { ignore: [0, 1, -1, 2, 100] },
-        ],
+        "@typescript-eslint/no-magic-numbers": [
+            "error",
+            {
+                "ignore": [0, 1, -1, 2, 100],
+                "detectObjects": true,
+                "ignoreReadonlyClassProperties": true,
+                "ignoreEnums": true,
+                "ignoreNumericLiteralTypes": true
+            }
+        ]
         'no-magic-numbers': 'off',
         '@typescript-eslint/ban-ts-ignore': 'off',
         '@typescript-eslint/explicit-function-return-type': 'off',


### PR DESCRIPTION
this is to allow

```
class Foo {
    readonly foo = 420;
}
```
and
```
enum Bar {
    bar = 69;
}
```
and
```
type MyNumber = 666;
```

they are not magic :reee: